### PR TITLE
Remove punycode.js dependency by inlining the `encode` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,5 @@
 , "scripts": {"postinstall": "./install.js", "update":"./install.js"}
 , "dependencies": {
     "bufferstream": ">= 0.5.0-pre"
-,   "punycode": ">= 1.0.0"
   }
 }


### PR DESCRIPTION
Some day, when punycode v1.1.1 lands in Node (v0.10), we can go back to `var encode = require('punycode').ucs2.encode`, but today is not that day.
