### PR TITLE
Fix postinstall and update scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/dodo/node-unicodetable.git"
   }
 , "engines": {"node": ">= 0.4.x"}
-, "scripts": {"postinstall": "./install.js", "update":"./install.js"}
+, "scripts": {"postinstall": "node install.js", "update": "node install.js"}
 , "dependencies": {
     "bufferstream": ">= 0.5.1"
   }


### PR DESCRIPTION
It seems that using

``` json
"scripts": {"postinstall": "./install.js", "update":"./install.js"}
```

does not work on Windows.

Instead 

``` json
"scripts": {"postinstall": "node install.js", "update":"node install.js"}
```

works on both Linux and Windows.
