### PR TITLE
process.exit code when downloading an unicode file fails

### DIFF
--- a/install.js
+++ b/install.js
@@ -129,11 +129,11 @@ function download_file(callback) {
         console.log("Please download file manually,",
                     "put it next to the install.js file and",
                     "run `node install.js` again.");
-        callback();
+        callback(1);
     });
     setTimeout(function () {
         console.error("request timed out.");
-        callback();
+        callback(1);
     }, 30 * 1000);
 }
 


### PR DESCRIPTION
Shouldn't install.js exit with 1, should it fail? This way, npm install will fail, should installing unicode fail.

I'm having this problem on deployment, in which a relatively big amount of modules need to be installed and I need to be notified if the installation failed.
