### PR TITLE
Added missing proxy fields

### DIFF
--- a/install.js
+++ b/install.js
@@ -131,10 +131,14 @@ function download_file(callback) {
 
         console.log('Proxy server detected, using proxy settings to download (%s)', proxyServer);
 
-        unicodedatafile.path = unicodedatafile.host
-                             + ":"
+        unicodedatafile.path = 'http://'
+                             + unicodedatafile.host
+                             + ':'
                              + unicodedatafile.port
                              + unicodedatafile.path;
+        unicodedatafile.headers = {
+          Host: unicodedatafile.host
+        };
         unicodedatafile.host = proxyVars[2];
         unicodedatafile.port = proxyVars[4];
     }
@@ -179,4 +183,3 @@ if (!module.parent) { // not required
         download_file:download_file,
     };
 }
-


### PR DESCRIPTION
When using http.get() to request a file through a proxy, the following were missing from the previous implementation:
- The `http://` protocol
- The `headers` object indicating the target `Host`

These additions are based on http://stackoverflow.com/a/6781592/1228454 and work for our company proxy (MS NTLM Proxy).

The previous implementation always silently failed, it simply exited the process right after the `fetching ...` message.
